### PR TITLE
ci: auto-merge main into daisyui on push

### DIFF
--- a/.github/workflows/sync-daisyui.yml
+++ b/.github/workflows/sync-daisyui.yml
@@ -1,0 +1,26 @@
+name: Sync daisyui
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: daisyui
+          fetch-depth: 0
+      - name: Merge main into daisyui
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if ! git merge origin/main --no-edit; then
+            echo "::error::Merge conflict in: $(git diff --name-only --diff-filter=U | tr '\n' ' '). Resolve manually on the daisyui branch."
+            exit 1
+          fi
+          git push origin daisyui


### PR DESCRIPTION
main への push をトリガーに daisyui ブランチへ自動 merge するワークフローを追加します。

- 両ブランチの依存バージョンが merge 経由で揃うため、繰り返し発生していた rebase コンフリクトが解消されます
- 機能追加・依存更新ともに自動で daisyui に反映されます
- コンフリクト時はワークフローが失敗し、コンフリクトしたファイル名をエラーに出します(手動解決が必要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XJC43KaNfsq8CiPMwmrCt